### PR TITLE
If OCREngine=2 and language not set, language code  is set `auto`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -233,6 +233,9 @@ class Client
 
     public function engine(int $engine = 1): self
     {
+        if ($engine === 2 && !$this->requestParameters->contains(RequestParameterEnum::LANGUAGE)) {
+            $this->requestParameters->attach(RequestParameterEnum::LANGUAGE, "auto");
+        }
         $this->requestParameters->attach(RequestParameterEnum::OCR_ENGINE, $engine);
         return $this;
     }

--- a/tests/Feature/ClientTest.php
+++ b/tests/Feature/ClientTest.php
@@ -286,4 +286,31 @@ class ClientTest extends TestCase
         $this->assertArrayHasKey('OCREngine', $options);
         $this->assertSame(2, $options['OCREngine']);
     }
+
+    public function testSetLanguageAutoIfEngineIs2()
+    {
+        $this->client
+            ->fromUrl("https://example.com/image.png")
+            ->isOverlayRequired(true)
+            ->fileType(FileTypeEnum::PDF)
+            ->engine(2);
+
+        $options = $this->client->options();
+        $this->assertArrayHasKey('language', $options);
+        $this->assertSame('auto', $options['language']);
+    }
+
+    public function testNotSetLanguageAutoIfEngineIs2AndLangWasSet()
+    {
+        $this->client
+            ->fromUrl("https://example.com/image.png")
+            ->language(LanguageCodeEnum::ENGLISH)
+            ->isOverlayRequired(true)
+            ->fileType(FileTypeEnum::PDF)
+            ->engine(2);
+
+        $options = $this->client->options();
+        $this->assertArrayHasKey('language', $options);
+        $this->assertSame('eng', $options['language']);
+    }
 }


### PR DESCRIPTION
The quote from doc API:
> [Engine2](https://ocr.space/OCRAPI#ocrengine) has automatic language detection. Use the value language=auto to enable it.